### PR TITLE
fix printf if no files were deleted by cleanup

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -58,8 +58,10 @@ files_dump() {
 # Logs the deleted files if any.
 cleanup() {
     printf "Cleanup\n"
-    find ${BACKUP_DIR} -maxdepth 1 -name "*.gz"  -type f -mtime +${KEEP_DAYS} -print -delete \
-    | printf " - No files deleted"
+    DELETED=$(find "${BACKUP_DIR}" -maxdepth 1 -name "*.gz"  -type f -mtime +"${KEEP_DAYS}" -print -delete)
+    if [[ -z $DELETED ]]; then
+        printf " - No files deleted"
+    fi
     printf "\n"
 }
 
@@ -74,4 +76,3 @@ printf "\n"
 # to do send mail
 # export AMB_REMOTE_EXEC="ssh -C $AMB_TARGET"
 # | mail -s "AutoMySQLBackup | $AMB_TARGET | `date +'%Y-%m-%d %r %Z'`" root
-


### PR DESCRIPTION
# MaRDI Pull Request

`find ... | printf "No files deleted"` would always print, regardless the output of find.

**Changes**:
- provide a check if files were found and deleted, or not



**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [x] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
