### PR TITLE
export metrics on backup

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -9,6 +9,10 @@ LOG_FILE="/data/backup.log" # internal path to log file
 BACKUP_DIR="/data" # internal mount path of backup directory on the host
 DATE_STRING=`date +\%Y.\%m.\%d_%H.%M.%S` # date string to use in file names
 
+NODE_EXPORTER_DIR="/data/"  # path where node_exporter metrics are stored
+XML_SIZE=0
+MYSQL_SIZE=0
+FILES_SIZE=0
 
 # redirect all output to log file
 exec 1>>$LOG_FILE
@@ -20,11 +24,14 @@ mysql_dump() {
     printf "MySQL backup\n"
     MYSQL_DUMP_FILE=portal_db_backup_${DATE_STRING}.gz
     mysqldump -u${DB_USER} -p${DB_PASS} -h${DB_HOST} --databases ${DB_NAME} | gzip > ${BACKUP_DIR}/${MYSQL_DUMP_FILE}
+    STATUS=$?
     if [[ -f ${BACKUP_DIR}/${MYSQL_DUMP_FILE} ]]; then
         printf " - MySQL dump written to ${MYSQL_DUMP_FILE}\n"
+        MYSQL_SIZE=$(du "${BACKUP_DIR}/${MYSQL_DUMP_FILE}" | cut -f1)
     else
-        printf " - MySQL dump failed with status $?\n"
+        printf " - MySQL dump failed with status $STATUS\n"
     fi
+    return $STATUS
 }
 
 # Backups the portal wiki pages as xml.
@@ -35,11 +42,14 @@ xml_dump() {
     # parsoid requires script to be executed from mw root
     cd /var/www/html/
     /usr/local/bin/php /var/www/html/maintenance/dumpBackup.php --current --output=gzip:${BACKUP_DIR}/${XML_DUMP_FILE} --quiet --conf /shared/LocalSettings.php
+    STATUS=$?
     if [[ -f ${BACKUP_DIR}/${XML_DUMP_FILE} ]]; then
         printf " - XML dump written to ${XML_DUMP_FILE}\n"
+        XML_SIZE=$(du "${BACKUP_DIR}/${XML_DUMP_FILE}" | cut -f1)
     else
-        printf " - XML dump failed with status $?\n"
+        printf " - XML dump failed with status $STATUS\n"
     fi    
+    return $STATUS
 }
 
 # Backups uploaded files
@@ -47,11 +57,14 @@ files_dump() {
     printf "Files backup\n"
     IMAGES_FILE=images_${DATE_STRING}.tar.gz
     tar -czf ${BACKUP_DIR}/${IMAGES_FILE} -C /var/www/html/ images
+    STATUS=$?
     if [[ -f ${BACKUP_DIR}/${IMAGES_FILE} ]]; then
         printf " - Uploaded images backup written to ${IMAGES_FILE}\n"
+        FILES_SIZE=$(du "${BACKUP_DIR}/${IMAGES_FILE}" | cut -f1)
     else
-        printf " - Uploaded images backup failed with status $?\n"
+        printf " - Uploaded images backup failed with status $STATUS\n"
     fi
+    return $STATUS
 }
 
 # Cleanups backup files older than KEEP_DAYS.
@@ -63,11 +76,59 @@ cleanup() {
     printf "\n"
 }
 
+# export metrics for prometheus/node_exporter textfile collector
+# metrics: 
+#   - date of last backup
+#   - backup file sizes
+#   - duration
+metrics_dump() {
+    printf "Writing backup metrics to file ${NODE_EXPORTER_DIR}/backup_full.prom\n"
+
+    cat << EOF > "${NODE_EXPORTER_DIR}/backup_full.prom.$$"
+# HELP backup_last_time_seconds system time of last backup in seconds
+# TYPE backup_last_time_seconds counter
+backup_last_time_seconds $END
+# HELP backup_last_duration_seconds duration of last backup in seconds
+# TYPE backup_last_duration_seconds gauge
+backup_last_duration_seconds $((END - START))
+# HELP backup_last_size_bytes file sizes in bytes of last backup
+# TYPE backup_last_size_bytes gauge
+backup_last_size_bytes{type="mysql"} $MYSQL_SIZE
+backup_last_size_bytes{type="xml"} $XML_SIZE
+backup_last_size_bytes{type="files"} $FILES_SIZE
+# HELP backup_total_size_bytes total size of backup folder in bytes
+# TYPE backup_total_size_bytes gauge
+backup_total_size_bytes $TOTAL_BACKUP_SIZE
+# HELP backup_last_status_code  status code of last backup call
+# TYPE backup_last_status_code gauge
+backup_last_status_code{type="mysql"} $EXIT_CODE_MYSQL
+backup_last_status_code{type="xml"} $EXIT_CODE_XML
+backup_last_status_code{type="files"} $EXIT_CODE_FILES
+EOF
+    
+    mv "${NODE_EXPORTER_DIR}/backup_full.prom.$$" "${NODE_EXPORTER_DIR}/backup_full.prom"
+}
+
+
 # main script
 printf "Backup started ${DATE_STRING}\n" 
+START="$(date +%s)"
+
 mysql_dump 
+EXIT_CODE_MYSQL=$?
+
 xml_dump
+EXIT_CODE_XML=$?
+
 files_dump
+EXIT_CODE_FILES=$?
+
+END="$(date +%s)"
+
+TOTAL_BACKUP_SIZE="$(du -s ${BACKUP_DIR} | cut -f1)"
+
+metrics_dump
+
 cleanup
 printf "\n"
 


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- backup.sh now writes textfile with metrics for prometheus
- metrics included:
  -  backup_last_time_seconds: system time of last backup in seconds
  - backup_last_duration_seconds: duration of last backup in seconds
  - backup_last_size_bytes: file sizes in bytes of last backup, for mysql/xml/files independently
  - backup_total_size_bytes: total size of backup folder in bytes
  - backup_last_status_code:  status code of last backup call, for mysql/xml/files independently

**TODO**:
- additional changes need to be made in portal-compose, but this is independent:
  - test if metrics are written
  - set up node_exporter to read file

**Instructions for PR review**:
- [x] Conceptual Review (Logic etc...) 
- [x] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [x] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
