### PR TITLE
toggle automatic backups via crontab with env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,25 @@ Example docker-compose configuration:
       DB_PASS: ${DB_PASS}
       BACKUP_SCHEDULE: ${BACKUP_SCHEDULE}
       KEEP_DAYS: 100
+      BACKUP_CRON_ENABLE: false
 ```
 
-These must be set in .env:
+These must be set in `.env`:
 
-BACKUP_DIR: Folder on the host where to put the backups. Folder ownership will be set to "backup:backup".
+`$BACKUP_DIR`: Folder on the host where to put the backups. Folder ownership will be set to `backup:backup`.
 
-DB_NAME: name of the database to backup
+`$DB_NAME`: name of the database to backup
 
-DB_USER: username of the database username
+`$DB_USER`: username of the database username
 
-DB_PASS: password of the database user
+`$DB_PASS`: password of the database user
 
-BACKUP_SCHEDULE: a cron string, e.g. '15 5 * * *' # every day at 05:15
+`$BACKUP_SCHEDULE`: a cron string, e.g. `'15 5 * * *' # every day at 05:15`
 
-KEEPD_DAYS: how many days shall the backups be kept, e.g. 100
+`$KEEP_DAYS`: how many days shall the backups be kept, e.g. 100
+
+`$BACKUP_CRON_ENABLE`: bool flag to enable/disable automatic backups via cron job when `start.sh` is called (e.g., as entrypoint of the backup container in https://github.com/mardi4nfdi/portal-compose)
+
 
 Creating a backup
 -----------------

--- a/start.sh
+++ b/start.sh
@@ -9,7 +9,7 @@ set +e
 # TIMEZONE is set in the Dockerfile
 cp /usr/share/zoneinfo/${TIMEZONE} /etc/localtime
 echo ${TIMEZONE} > /etc/timezone
-echo "Date: `date`."
+echo "Date: $(date)."
 
 # Set up backup group.
 # BACKUP_GID is set in the Dockerfile
@@ -36,7 +36,14 @@ chown -R backup:backup /data
 # CRONTAB is set in the Dockerfile
 # CRON_SCHEDULE and the other environment variables are set in docker-compose.yml
 echo "" > $CRONTAB
-echo "${BACKUP_SCHEDULE} DB_HOST=${DB_HOST} DB_NAME=${DB_NAME} DB_USER=${DB_USER} DB_PASS=${DB_PASS} KEEP_DAYS=${KEEP_DAYS} /app/backup.sh" >> $CRONTAB
+
+if [ "$BACKUP_CRON_ENABLE" = true ]; then
+    echo "Setting up backup cronjob"
+    echo "${BACKUP_SCHEDULE} DB_HOST=${DB_HOST} DB_NAME=${DB_NAME} DB_USER=${DB_USER} DB_PASS=${DB_PASS} KEEP_DAYS=${KEEP_DAYS} /app/backup.sh" >> $CRONTAB
+else
+    echo "Setting up do-nothing cronjob: automatic backups are disabled"
+fi
+
 crontab -u backup - < /var/spool/cron/crontabs/backup
 
 #echo "Starting cron."

--- a/start.sh
+++ b/start.sh
@@ -35,13 +35,13 @@ chown -R backup:backup /data
 # Set up crontab.
 # CRONTAB is set in the Dockerfile
 # CRON_SCHEDULE and the other environment variables are set in docker-compose.yml
-echo "Setting up backup cronjob"
 echo "" > $CRONTAB
-echo "${BACKUP_SCHEDULE} DB_HOST=${DB_HOST} DB_NAME=${DB_NAME} DB_USER=${DB_USER} DB_PASS=${DB_PASS} KEEP_DAYS=${KEEP_DAYS} /app/backup.sh" >> $CRONTAB
 
-if [ "$BACKUP_CRON_ENABLE" != true ]; then
-    echo " - do-nothing cronjob: automatic backups are disabled"
-    echo "" > $CRONTAB
+if [ "$BACKUP_CRON_ENABLE" = true ]; then
+    echo "Setting up backup cronjob"
+    echo "${BACKUP_SCHEDULE} DB_HOST=${DB_HOST} DB_NAME=${DB_NAME} DB_USER=${DB_USER} DB_PASS=${DB_PASS} KEEP_DAYS=${KEEP_DAYS} /app/backup.sh" >> $CRONTAB
+else
+    echo "Setting up do-nothing cronjob: automatic backups are disabled"
 fi
 
 crontab -u backup - < /var/spool/cron/crontabs/backup

--- a/start.sh
+++ b/start.sh
@@ -35,13 +35,13 @@ chown -R backup:backup /data
 # Set up crontab.
 # CRONTAB is set in the Dockerfile
 # CRON_SCHEDULE and the other environment variables are set in docker-compose.yml
+echo "Setting up backup cronjob"
 echo "" > $CRONTAB
+echo "${BACKUP_SCHEDULE} DB_HOST=${DB_HOST} DB_NAME=${DB_NAME} DB_USER=${DB_USER} DB_PASS=${DB_PASS} KEEP_DAYS=${KEEP_DAYS} /app/backup.sh" >> $CRONTAB
 
-if [ "$BACKUP_CRON_ENABLE" = true ]; then
-    echo "Setting up backup cronjob"
-    echo "${BACKUP_SCHEDULE} DB_HOST=${DB_HOST} DB_NAME=${DB_NAME} DB_USER=${DB_USER} DB_PASS=${DB_PASS} KEEP_DAYS=${KEEP_DAYS} /app/backup.sh" >> $CRONTAB
-else
-    echo "Setting up do-nothing cronjob: automatic backups are disabled"
+if [ "$BACKUP_CRON_ENABLE" != true ]; then
+    echo " - do-nothing cronjob: automatic backups are disabled"
+    echo "" > $CRONTAB
 fi
 
 crontab -u backup - < /var/spool/cron/crontabs/backup


### PR DESCRIPTION
# MaRDI Pull Request

per https://github.com/MaRDI4NFDI/T5ProjectManagement/issues/68
requires deployment of https://github.com/MaRDI4NFDI/portal-compose/pull/195 

**Changes**:
- `start.sh` (docker entrypoint) only sets up cronjob from options if `$BACKUP_CRON_ENABLE` is true, else an empty "dummy" cronjob is created, s.t. the container keeps running but does nothing. This means that one can connect via `docker exec -ti mardi-backup /bin/bash` (or call `docker exec mardi-backup /app/backup.sh|restore.sh`) manually and test the backup.


**Instructions for PR review**:
- [x] Conceptual Review (Logic etc...) 
- [x] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
