### PR TITLE
Fix importimage overwrite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
 		gzip \
 		tzdata \
 		nano \
+        vim \
 	&& rm -rf /var/cache/apk/*
+    
 
 # Set up non-root user.
 # RUN addgroup -g "$BACKUP_DEFAULT_GID" backup \BACKUP_DEFAULT_GID

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ RUN adduser \
 		-G "backup" \
 		backup
 
+COPY --from=ghcr.io/mardi4nfdi/docker-wikibase:main /var/www/html/ /var/www/html/
+
 # Copy files.
 RUN mkdir /app
 COPY backup.sh /app/
@@ -43,7 +45,6 @@ COPY start.sh /app/
 
 # Make sure scripts are executable
 RUN chown backup:backup /app/*.sh && chmod 774 /app/*.sh
-COPY --from=ghcr.io/mardi4nfdi/docker-wikibase:main /var/www/html/ /var/www/html/
 
 # Set up entry point.
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Open a shell to the backup container. In the /app dir, do:
 * `bash ./restore.sh -t xml -f portal_xml_backup_xxxx.xx.xx_xx.xx.xx.gz` to restore a specific XML backup. Pass the name of the file, not the full path.
 * `bash ./restore.sh -t img` to restore the latest images backup
 * `bash ./restore.sh -t img -f images_xxxx.xx.xx_xx.xx.xx.tar.gz` to restore a specific image backup. Pass the name of the file, not the full path.
+* `bash ./restore.sh -t img -o [-f FILE]` to restore an image backup, overwriting existing files.
 
 **Please note that:** 
 * When restoring the database from a SQL backup, all revisions will be overwritten.

--- a/README.md
+++ b/README.md
@@ -61,15 +61,20 @@ To run a backup manually, do `docker exec -ti name-of-backup-container ./backup.
 Restoring a backup
 -------------------
 Open a shell to the backup container. In the /app dir, do:
-* `bash ./restore.sh` to restore the database from the latest SQL dump 
-* `bash ./restore.sh -f portal_db_backup_xxxx.xx.xx_xx.xx.xx.gz` to restore a specific SQL dump. Pass the name of the file, not the full path.
-* `bash ./restore.sh -t sql -f portal_db_backup_xxxx.xx.xx_xx.xx.xx.gz` same as above
+* `bash ./restore.sh -h` shows the help text 
+* `bash ./restore.sh` to restore the database from the latest SQL dump and the last image backup
+* `bash ./restore.sh -t sql -f portal_db_backup_xxxx.xx.xx_xx.xx.xx.gz` to restore a specific SQL dump. Pass the name of the file, not the full path.
 * `bash ./restore.sh -t xml` to restore the wiki pages from the latest XML backup 
 * `bash ./restore.sh -t xml -f portal_xml_backup_xxxx.xx.xx_xx.xx.xx.gz` to restore a specific XML backup. Pass the name of the file, not the full path.
+* `bash ./restore.sh -t img` to restore the latest images backup
+* `bash ./restore.sh -t img -f images_xxxx.xx.xx_xx.xx.xx.tar.gz` to restore a specific image backup. Pass the name of the file, not the full path.
 
 **Please note that:** 
 * When restoring the database from a SQL backup, all revisions will be overwritten.
 * When restoring the pages from an XML backup, if a page has a newer revision than the page in the backup, then the newer revision will be kept.
+* When restoring the images directory, all existing files will be overwritten, and
+  existing files inside `/var/www/html/images/` will be kept if not present in the
+  backup (make sure to delete that folder first if keeping old files is not desired).
 
 Pages erased since the backup was made will be restored. 
 
@@ -77,7 +82,3 @@ Tests
 ------
 This thing only works if there's a wiki to backup, therefore the tests are in the portal-compose repo. 
 Start the portal from docker-compose-dev.yml and call `bash run_tests.sh` to run all tests.
-
-To do
-------
-* Email out reports through ssmtp

--- a/restore.sh
+++ b/restore.sh
@@ -60,7 +60,7 @@ restore_images_backup() {
     mkdir -p "$IMAGE_BACKUP_DIR"
     tar -xzf "$BACKUP_FILE" -C "$IMAGE_BACKUP_DIR" images
     # import images as apache user, in order to get the correct permissions
-    su -l www-data -s /bin/bash -c 'php /var/www/html/maintenance/importImages.php --search-recursively --conf /shared/LocalSettings.php --comment "Importing images backup" '"$IMAGE_BACKUP_DIR"'/images'
+    su -l www-data -s /bin/bash -c 'php /var/www/html/maintenance/importImages.php '"$IMG_OPT_FLAGS"' --search-recursively --conf /shared/LocalSettings.php --comment "Importing images backup" '"$IMAGE_BACKUP_DIR"'/images'
     rm -rf "$IMAGE_BACKUP_DIR"
 
     if [[ $? -eq 0 ]]; then
@@ -88,6 +88,7 @@ _help() {
     printf "                                            -t xml     XML backup\n"
     printf "                                            -t sql     MySQL backup\n"
     printf "                                            -t img     images backup\n"
+    printf "        restore.sh -t img -o [-f file]  restore image backup, overwriting existing images\n"
 
 }
 
@@ -97,10 +98,11 @@ _help() {
 ###########################
 
 # Handle input flags
-while getopts "ht:f:" flag; do
+while getopts "ht:of:" flag; do
 case ${flag} in
     t) BACKUP_TYPE=$OPTARG;;
     f) BACKUP_FILE=$OPTARG;;
+    o) IMG_OPT_FLAGS="--overwrite";;
     h) _help
         exit 0;;
     \?) _help

--- a/restore.sh
+++ b/restore.sh
@@ -5,7 +5,7 @@
 
 set -e # do not continue on error
 
-LOG_FILE="/data/backup.log" # internal path to log file
+LOG_FILE="/data/restore.log" # internal path to log file
 BACKUP_DIR="/data" # internal mount path of backup directory on the host
 
 # redirect all output to log file
@@ -22,6 +22,7 @@ _det_file() {
         case ${BACKUP_TYPE} in
             sql) BACKUP_FILE=$(ls -t ${BACKUP_DIR}/portal_db_backup_*.gz | head -1);;
             xml) BACKUP_FILE=$(ls -t ${BACKUP_DIR}/portal_xml_backup_*.gz | head -1);;
+            img) BACKUP_FILE=$(ls -t ${BACKUP_DIR}/images_*.gz | head -1);;
         esac
     else
         # a backup file was passed to the command line, prepend the full path to the backup folder (as mounted in the container)
@@ -49,6 +50,27 @@ restore_db_backup() {
     fi
 }
 
+restore_images_backup() {
+    _det_file
+    printf "Restoring images directory backup from $BACKUP_FILE\n"
+    # use importImages.php maintenance script https://www.mediawiki.org/wiki/Manual:ImportImages.php
+    # extract files to /tmp/
+    FILE_NAME=$(basename -- $BACKUP_FILE)
+    IMAGE_BACKUP_DIR=/tmp/${FILE_NAME%.*.*}
+    mkdir -p "$IMAGE_BACKUP_DIR"
+    tar -xzf "$BACKUP_FILE" -C "$IMAGE_BACKUP_DIR" images
+    # import images as apache user, in order to get the correct permissions
+    su -l www-data -s /bin/bash -c 'php /var/www/html/maintenance/importImages.php --search-recursively --conf /shared/LocalSettings.php --comment "Importing images backup" '"$IMAGE_BACKUP_DIR"'/images'
+    rm -rf "$IMAGE_BACKUP_DIR"
+
+    if [[ $? -eq 0 ]]; then
+        printf "Done\n"
+    else
+        printf "ERROR restoring images directory\n\n"
+        exit 1
+    fi
+}
+
 # Restores a XML backup
 # If no XML file was specified from the command line (-f filename), then the most recent XML backup is restored.
 # https://www.mediawiki.org/wiki/Manual:Importing_XML_dumps
@@ -58,30 +80,58 @@ restore_xml_backup() {
     cd /var/www/html/ && php maintenance/importDump.php --conf /shared/LocalSettings.php $BACKUP_FILE --username-prefix=""
 }
 
+_help() {
+    printf "Usage:  restore.sh                      restore last MySQL and images backups\n"
+    printf "        restore.sh -t type              restore last backup of given type\n"
+    printf "        restore.sh -t type -f file      restore backup of given type from file\n\n"
+    printf "          _OVERWRITE                              supported type:\n"
+    printf "                                            -t xml     XML backup\n"
+    printf "                                            -t sql     MySQL backup\n"
+    printf "                                            -t img     images backup\n"
+
+}
+
+
 ###########################
 #       Main script       #
 ###########################
 
-printf "Restore started at `date +\%Y.\%m.\%d_%H.%M.%S`\n"
-
 # Handle input flags
-BACKUP_TYPE=sql
-while getopts "t:f:" flag; do
+while getopts "ht:f:" flag; do
 case ${flag} in
     t) BACKUP_TYPE=$OPTARG;;
     f) BACKUP_FILE=$OPTARG;;
+    h) _help
+        exit 0;;
+    \?) _help
+        exit 1;;
 esac
 done
 
+if [[ "$BACKUP_FILE" ]] && [[ -z "$BACKUP_TYPE" ]]; then
+    printf "ERROR: missing option -t type\n\n"
+    _help
+    exit 1
+fi
+
+printf "Restore started at `date +\%Y.\%m.\%d_%H.%M.%S`\n"
+
 # call restore from sql backup by default
-if [[ -z "${BACKUP_TYPE}" ]]; then
+if [[ -z "$BACKUP_TYPE" ]]; then
+    BACKUP_TYPE=sql
     restore_db_backup
+    unset BACKUP_FILE
+    BACKUP_TYPE=img
+    restore_images_backup
 else
     # a backup type was set explicitly
     case ${BACKUP_TYPE} in
         sql) restore_db_backup;;
         xml) restore_xml_backup;;
-        *) printf "Unknown backup type ${BACKUP_TYPE}\n\n"; exit 1;;
+        img) restore_images_backup;;
+        *) printf "ERROR: Unknown backup type \"${BACKUP_TYPE}\"\n\n"
+            _help
+            exit 1;;
     esac
 fi
 printf "\n"

--- a/restore.sh
+++ b/restore.sh
@@ -84,7 +84,7 @@ _help() {
     printf "Usage:  restore.sh                      restore last MySQL and images backups\n"
     printf "        restore.sh -t type              restore last backup of given type\n"
     printf "        restore.sh -t type -f file      restore backup of given type from file\n\n"
-    printf "          _OVERWRITE                              supported type:\n"
+    printf "                                        supported type:\n"
     printf "                                            -t xml     XML backup\n"
     printf "                                            -t sql     MySQL backup\n"
     printf "                                            -t img     images backup\n"


### PR DESCRIPTION
# MaRDI Pull Request

`importImages.php` has an `--overwrite` flag, which is very useful in case, for instance, a corrupted image file (like from a failed restore) is present in the wiki. however, this option does not work atm. I suspect a bug in mediawiki and filed a report: https://phabricator.wikimedia.org/T309785

-  hence blocked until this is clarified

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
