### PR TITLE
img restore: ignore deleted and thumb folders

### DIFF
--- a/restore.sh
+++ b/restore.sh
@@ -55,12 +55,18 @@ restore_images_backup() {
     printf "Restoring images directory backup from $BACKUP_FILE\n"
     # use importImages.php maintenance script https://www.mediawiki.org/wiki/Manual:ImportImages.php
     # extract files to /tmp/
-    FILE_NAME=$(basename -- $BACKUP_FILE)
+    IGNORE_FOLDERS=(deleted thumb)
+    FILE_NAME=$(basename -- "$BACKUP_FILE")
     IMAGE_BACKUP_DIR=/tmp/${FILE_NAME%.*.*}
     mkdir -p "$IMAGE_BACKUP_DIR"
     tar -xzf "$BACKUP_FILE" -C "$IMAGE_BACKUP_DIR" images
+    for ignore in "${IGNORE_FOLDERS[@]}"; do
+        rm -rf "$IMAGE_BACKUP_DIR/images/$ignore"
+    done
+
     # import images as apache user, in order to get the correct permissions
     su -l www-data -s /bin/bash -c 'php /var/www/html/maintenance/importImages.php --search-recursively --conf /shared/LocalSettings.php --comment "Importing images backup" '"$IMAGE_BACKUP_DIR"'/images'
+
     rm -rf "$IMAGE_BACKUP_DIR"
 
     if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
# MaRDI Pull Request

fixes #26 

`images/deleted` and `images/thumb` folders will be ignored when restoring image backup

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
