### PR TITLE
enable docker logging via named pipes and fix error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Docker image for backups
 A Docker image that runs backups on a regular basis.
 
 * Creates a "backup" user
-* Calls the backup script (./backup.sh) on a regular basis (BACKUP_SCHEDULE) using cron
+* Calls the backup script (`./backup.sh`) on a regular basis (BACKUP_SCHEDULE) using cron
 * Saves backups of database and pages (in XML format) as compressed files on the host (BACKUP_DIR)
 * Deletes old backups (older than KEEP_DAYS)
 
@@ -33,7 +33,7 @@ Example docker-compose configuration:
       DB_PASS: ${DB_PASS}
       BACKUP_SCHEDULE: ${BACKUP_SCHEDULE}
       KEEP_DAYS: 100
-      BACKUP_CRON_ENABLE: false
+      BACKUP_CRON_ENABLE: true
 ```
 
 These must be set in `.env`:
@@ -57,6 +57,8 @@ Creating a backup
 -----------------
 Normally, backups are created by a cronjob. 
 To run a backup manually, do `docker exec -ti name-of-backup-container ./backup.sh`
+Output of `backup.sh` is logged to the file `$BACKUP_DIR/backup.log` and to the logs of
+the docker container.
 
 Restoring a backup
 -------------------
@@ -74,6 +76,8 @@ Open a shell to the backup container. In the /app dir, do:
 * When restoring the pages from an XML backup, if a page has a newer revision than the page in the backup, then the newer revision will be kept (in particular the main page of a newly created mediawiki).
 
 Pages erased since the backup was made will be restored. 
+
+In order to include the output of `restore.sh` in the logs, execute `restore.sh > /tmp/stdout 2> /tmp/stderr`.
 
 Tests
 ------

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Creating a backup
 -----------------
 Normally, backups are created by a cronjob. 
 To run a backup manually, do `docker exec -ti name-of-backup-container ./backup.sh`
-Output of `backup.sh` is logged to the file `$BACKUP_DIR/backup.log` and to the logs of
-the docker container.
+The cronjob automatically logs the output of `backup.sh` is logged 1) in the docker logs and in the files `$BACKUP_DIR/backup.log` (normal output/stdout) and `$BACKUP_DIR/backup_errors.log` (error messages/stderr).
+To also log manually executed scripts, use, e.q.,  `docker exec -ti mardi-backup bash -c './backup.sh > /tmp/stdout 2> /tmp/stderr'`
 
 Restoring a backup
 -------------------

--- a/start.sh
+++ b/start.sh
@@ -7,13 +7,13 @@ set +e
 
 # Adjust timezone.
 # TIMEZONE is set in the Dockerfile
-cp /usr/share/zoneinfo/${TIMEZONE} /etc/localtime
-echo ${TIMEZONE} > /etc/timezone
+cp "/usr/share/zoneinfo/${TIMEZONE}" /etc/localtime
+echo "$TIMEZONE" > /etc/timezone
 echo "Date: $(date)."
 
 # Set up backup group.
 # BACKUP_GID is set in the Dockerfile
-: ${BACKUP_GID:="$BACKUP_DEFAULT_GID"}
+: "${BACKUP_GID:=$BACKUP_DEFAULT_GID}"
 if [ "$(id -g backup)" != "$BACKUP_GID" ]; then
 	groupmod -o -g "$BACKUP_GID" backup
 fi
@@ -21,7 +21,7 @@ echo "Using group ID $(id -g backup)."
 
 # Set up backup user.
 # BACKUP_UID is set in the Dockerfile
-: ${BACKUP_UID:="$BACKUP_DEFAULT_UID"}
+: "${BACKUP_UID:=$BACKUP_DEFAULT_UID}"
 if [ "$(id -u backup)" != "$BACKUP_UID" ]; then
 	usermod -o -u "$BACKUP_UID" backup
 fi
@@ -35,16 +35,25 @@ chown -R backup:backup /data
 # Set up crontab.
 # CRONTAB is set in the Dockerfile
 # CRON_SCHEDULE and the other environment variables are set in docker-compose.yml
-echo "" > $CRONTAB
+echo "" > "$CRONTAB"
 
 if [ "$BACKUP_CRON_ENABLE" = true ]; then
     echo "Setting up backup cronjob"
-    echo "${BACKUP_SCHEDULE} DB_HOST=${DB_HOST} DB_NAME=${DB_NAME} DB_USER=${DB_USER} DB_PASS=${DB_PASS} KEEP_DAYS=${KEEP_DAYS} /app/backup.sh" >> $CRONTAB
+    echo "${BACKUP_SCHEDULE} DB_HOST=${DB_HOST} DB_NAME=${DB_NAME} DB_USER=${DB_USER} DB_PASS=${DB_PASS} KEEP_DAYS=${KEEP_DAYS} /app/backup.sh > /tmp/stdout 2> /tmp/stderr" >> "$CRONTAB"
 else
     echo "Setting up do-nothing cronjob: automatic backups are disabled"
 fi
 
 crontab -u backup - < /var/spool/cron/crontabs/backup
+
+# create custom named pipes for stdout and stderr
+mkfifo /tmp/stdout /tmp/stderr
+chmod 0666 /tmp/stdout /tmp/stderr
+
+BACKUP_DIR="/data" # internal mount path of backup directory on the host
+# make docker main process tail stdout and stderr
+tail -f /tmp/stdout | tee -a "$BACKUP_DIR"/backup.log &
+tail -f /tmp/stderr | tee -a "$BACKUP_DIR"/backup_errors.log &
 
 #echo "Starting cron."
 exec cron -l 8 -f


### PR DESCRIPTION
# MaRDI Pull Request

#28 

**Changes**:
- only cronjob backup logs now shows up in `docker logs`
- manually calling restore.sh and backup.sh does not log automatically, but prints to the terminal
- README explains how to also log manually executed scripts (if really desired...)
- docker logs include both stdout and stderr
- stdout is also logged to file /data/backup.log, stderr goes to /data/backup_errors.log
- in addition, fix error handling (& improve shellcheck confirmity) of the bash scripts

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
