### PR TITLE
improve logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM php:7.4-cli
 # some defaults
 ENV BACKUP_DEFAULT_GID="9000" \
 	BACKUP_DEFAULT_UID="9000" \
+    BACKUP_DIR="/data" \
 	TIMEZONE="CET" \
 	DEFAULT_SCHEDULE="0 1 * * *" \
 	CRONTAB="/var/spool/cron/crontabs/backup"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ These must be set in `.env`:
 
 `$DB_PASS`: password of the database user
 
-`$BACKUP_SCHEDULE`: a cron string, e.g. `'15 5 * * *' # every day at 05:15`
+`$BACKUP_SCHEDULE`: a cron string, e.g. `15 5 * * *` (no quotes; daily backups at 5:15AM)
 
 `$KEEP_DAYS`: how many days shall the backups be kept, e.g. 100
 
@@ -57,8 +57,7 @@ Creating a backup
 -----------------
 Normally, backups are created by a cronjob. 
 To run a backup manually, do `docker exec -ti name-of-backup-container ./backup.sh`.
-The cronjob automatically logs the output of `backup.sh` in 1) the docker logs and 2) in the files `$BACKUP_DIR/backup.log` (standard output) and `$BACKUP_DIR/backup_errors.log` (error messages).
-To also log manually executed scripts, use, e.q.,  `docker exec -ti mardi-backup bash -c './backup.sh > /tmp/stdout 2> /tmp/stderr'`
+The cronjob automatically logs the output of `backup.sh` in 1) the docker container logs (`docker logs -f name-of-backup-container`) and 2) in the file `$BACKUP_DIR/backup.log`.
 
 Restoring a backup
 -------------------
@@ -77,7 +76,8 @@ Open a shell to the backup container. In the /app dir, do:
 
 Pages erased since the backup was made will be restored. 
 
-In order to include the output of `restore.sh` in the logs, execute `restore.sh > /tmp/stdout 2> /tmp/stderr`.
+The output of `restore.sh` is logged to `$BACKUP_DIR/restore.log` and to the docker
+container logs.
 
 Tests
 ------

--- a/backup.sh
+++ b/backup.sh
@@ -5,10 +5,13 @@
 
 set +e # continue on error
 
-BACKUP_DIR="/data" # internal mount path of backup directory on the host
 DATE_STRING=$(date +%Y.%m.%d_%H.%M.%S)  # date string to use in file names
 
-NODE_EXPORTER_DIR="/data/"  # path where node_exporter metrics are stored
+# redirect all output to stdout && log file
+# Note: $BACKUP_DIR is set in the Dockerfile.
+exec &> >(tee -a "$BACKUP_DIR/backup.log")
+
+NODE_EXPORTER_DIR="$BACKUP_DIR"  # path where node_exporter metrics are stored
 XML_SIZE=0
 MYSQL_SIZE=0
 FILES_SIZE=0
@@ -140,8 +143,9 @@ EOF
 
 
 # main script
-printf '==================================\n' | tee /tmp/stderr 
-printf 'Backup started %s\n' "$DATE_STRING" | tee /tmp/stderr 
+printf '==================================\n'
+printf 'Backup started %s\n' "$DATE_STRING"
+printf '==================================\n'
 START="$(date +%s)"
 
 mysql_dump 


### PR DESCRIPTION
# MaRDI Pull Request

Logging was quite unreliable, so adapt a combination of the new and previous solution for robust logging.
This achieves output to logging files `/data/backup.log` and `restore.log`, to the terminal (useful for manual execution and testing), and to the docker container logs.

**Changes**:
- do not use named pipes, but redirect output to stdout and file inside the scripts
- let start.sh entrypoint tail the log files, to include the output in the docker logs


**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
